### PR TITLE
Use the correct featurizer preset for composition-only tasks

### DIFF
--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -112,6 +112,7 @@ def featurize(task, n_jobs=1):
         featurizer=featurizer,
     )
     data.featurize(n_jobs=n_jobs)
+    os.makedirs("./precomputed", exist_ok=True)
     data.save(f"./precomputed/{task}_moddata.pkl.gz")
     return data
 

--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -891,7 +891,9 @@ if __name__ == "__main__":
         arg = args.get("task")
         task = "matbench_" + arg.replace("matbench_", "")
 
-    n_jobs = args.get("n_jobs", 4)
+    n_jobs = args.get("n_jobs")
+    if n_jobs is None:
+        n_jobs = 4
 
     if not os.path.isdir(task):
         raise RuntimeError(f"No folder found for {task!r}.")

--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -95,17 +95,21 @@ def featurize(task, n_jobs=1):
         col for col in df.columns if col not in ("id", "structure", "composition")
     ]
 
+    if "structure" not in df.columns:
+        featurizer = CompositionOnlyFeaturizer()
+    else:
+        featurizer = DeBreuck2020Featurizer(fast_oxid=True)
+
     try:
         materials = df["structure"] if "structure" in df.columns else df["composition"].map(Composition)
     except KeyError:
         raise RuntimeError(f"Could not find any materials data dataset for task {task!r}!")
 
-    fast_oxid_featurizer = DeBreuck2020Featurizer(fast_oxid=True)
     data = MODData(
         materials=materials.tolist(),
         targets=df[targets].values,
         target_names=targets,
-        featurizer=fast_oxid_featurizer,
+        featurizer=featurizer,
     )
     data.featurize(n_jobs=n_jobs)
     data.save(f"./precomputed/{task}_moddata.pkl.gz")


### PR DESCRIPTION
At some point we had to specify that the `DeBreuck2020Featurizer` should use `fast_oxid=True` for these benchmarks, which meant that we had to manually create the featurizer in `run_benchmark.py` rather than letting MODNet figure out which one to use. This meant that the few composition-only tasks could not be featurized directly with this script.

This PR also:
 - add `--n_jobs` as a command-line flag that is used throughout.
 - makes sure that the `precomputed` folder is created if it is missing